### PR TITLE
remove 'Content-Type'

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -47,7 +47,6 @@ function App() {
   function fetchStations() {
     fetch(url, {
       headers: {
-        'Content-Type': 'application/json',
         Authorization: `Bearer ${stationsApiKey}`,
       },
     })


### PR DESCRIPTION
We removed 'Content-Type' to fix a bug with the api.